### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ http = urllib3.PoolManager(
     )
 )
 thread_pool = ThreadPoolExecutor()
-top_pypi_packages_url = "https://raw.githubusercontent.com/hugovk/top-pypi-packages/main/top-pypi-packages-30-days.min.json"
+top_pypi_packages_url = "https://raw.githubusercontent.com/hugovk/top-pypi-packages/main/top-pypi-packages.min.json"
 today = datetime.date.today().strftime("%Y-%m-%d")
 base_dir = Path(__file__).absolute().parent
 


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.